### PR TITLE
#2 stub WTS HTTP calls with webmock

### DIFF
--- a/test/zold/test_wts.rb
+++ b/test/zold/test_wts.rb
@@ -15,8 +15,15 @@ require_relative '../../lib/zold/wts'
 class TestWTS < Minitest::Test
   KEY = '0000000000000000-b416493aefae4ca487c4739050aaec15'
 
+  def setup
+    WebMock.disable_net_connect!
+  end
+
   def test_pulls
-    WebMock.allow_net_connect!
+    stub_request(:get, 'https://wts.zold.io/pull')
+      .to_return(headers: { 'X-Zold-Job' => 'job-pull' })
+    stub_request(:get, %r{https://wts\.zold\.io/job\?id=.*})
+      .to_return(body: 'OK')
     wts = Zold::WTS.new(KEY, log: Loog::VERBOSE)
     job = wts.pull
     wts.wait(job)
@@ -24,7 +31,12 @@ class TestWTS < Minitest::Test
   end
 
   def test_finds_transactions
-    WebMock.allow_net_connect!
+    stub_request(:get, 'https://wts.zold.io/pull')
+      .to_return(headers: { 'X-Zold-Job' => 'job-find' })
+    stub_request(:get, %r{https://wts\.zold\.io/job\?id=.*})
+      .to_return(body: 'OK')
+    stub_request(:get, %r{https://wts\.zold\.io/find\?.*})
+      .to_return(body: '')
     wts = Zold::WTS.new(KEY, log: Loog::VERBOSE)
     job = wts.pull
     wts.wait(job)
@@ -32,7 +44,8 @@ class TestWTS < Minitest::Test
   end
 
   def test_retrieves_wallet_id
-    WebMock.allow_net_connect!
+    stub_request(:get, 'https://wts.zold.io/id')
+      .to_return(body: '0000000000000000')
     wts = Zold::WTS.new(KEY, log: Loog::VERBOSE)
     assert(!wts.id.nil?)
   end
@@ -43,7 +56,12 @@ class TestWTS < Minitest::Test
   end
 
   def test_retrieves_balance
-    WebMock.allow_net_connect!
+    stub_request(:get, 'https://wts.zold.io/pull')
+      .to_return(headers: { 'X-Zold-Job' => 'job-balance' })
+    stub_request(:get, %r{https://wts\.zold\.io/job\?id=.*})
+      .to_return(body: 'OK')
+    stub_request(:get, 'https://wts.zold.io/balance')
+      .to_return(body: '100000000')
     wts = Zold::WTS.new(KEY, log: Loog::VERBOSE)
     job = wts.pull
     wts.wait(job)
@@ -51,14 +69,14 @@ class TestWTS < Minitest::Test
   end
 
   def test_retrieves_usd_rate
-    WebMock.allow_net_connect!
+    stub_request(:get, 'https://wts.zold.io/usd_rate')
+      .to_return(body: '5000.0')
     wts = Zold::WTS.new(KEY, log: Loog::VERBOSE)
     rate = wts.usd_rate
     assert(!rate.nil?)
   end
 
   def test_works_with_fake
-    WebMock.allow_net_connect!
     wts = Zold::WTS::Fake.new
     job = wts.pull
     wts.wait(job)
@@ -66,7 +84,6 @@ class TestWTS < Minitest::Test
   end
 
   def test_works_with_webmock
-    WebMock.disable_net_connect!
     stub_request(:get, 'https://wts.zold.io/usd_rate').to_return(body: '1.234')
     wts = Zold::WTS.new('fake', log: Loog::VERBOSE)
     assert_equal(1.234, wts.usd_rate)


### PR DESCRIPTION
Issue #2 asks for `webmock`-based unit tests because the existing suite reaches the live WTS at `https://wts.zold.io` for every test. The existing tests call `WebMock.allow_net_connect!`, so any failure or latency on the third-party host produces a red CI run, and the suite cannot be relied on as a unit-level signal for the code in `lib/zold/wts.rb`.

This change replaces the live calls in `test/zold/test_wts.rb` with `webmock` stubs covering `/pull`, `/job?id=...`, `/balance`, `/id`, `/find?...`, and `/usd_rate`, and moves `WebMock.disable_net_connect!` into a `setup` hook so no test can leak to the network. The eight existing tests still cover the same code paths in `Zold::WTS` and `Zold::WTS::Fake`, but each one now finishes in milliseconds and never depends on `wts.zold.io` being reachable.

Locally on Ruby 3.3.6: `bundle exec rake test` runs all 8 tests in under one second with 0 failures and 86.67% line coverage; the previous run on `master` took roughly 24 seconds against the live host. The `rake rubocop` step exhibits the same `rubocop-rspec_rails` `inject_defaults!` failure as `master`, so this branch does not introduce a new lint failure.

Closes #2
