### PR TITLE
#3 add sell() to convert ZLD to BTC

### DIFF
--- a/lib/zold/wts.rb
+++ b/lib/zold/wts.rb
@@ -35,6 +35,10 @@ class Zold::WTS
       'job-id'
     end
 
+    def sell(_keygap, _btc, _amount)
+      'job-id'
+    end
+
     def usd_rate
       5_000
     end
@@ -129,6 +133,28 @@ class Zold::WTS
       )
     )
     @log.debug("PAY job #{job} started in #{Zold::Age.new(start)}")
+    job
+  end
+
+  # Initiate SELL request to convert ZLD to BTC. The <tt>keygap</tt> is the
+  # string you get when you confirm the account. The <tt>btc</tt> is the
+  # Bitcoin address to receive the funds. The <tt>amount</tt> is the amount
+  # in ZLD, e.g. "0.5".
+  #
+  # The method returns the job ID, which you should wait for completion
+  # using the method <tt>wait()</tt>.
+  def sell(keygap, btc, amount)
+    start = Time.now
+    job = job_of(
+      clean(
+        Typhoeus::Request.post(
+          'https://wts.zold.io/do-zld-to-btc',
+          headers: headers,
+          body: { keygap: keygap, btc: btc, amount: amount }
+        )
+      )
+    )
+    @log.debug("SELL job #{job} started in #{Zold::Age.new(start)}")
     job
   end
 

--- a/test/zold/test_wts.rb
+++ b/test/zold/test_wts.rb
@@ -71,4 +71,19 @@ class TestWTS < Minitest::Test
     wts = Zold::WTS.new('fake', log: Loog::VERBOSE)
     assert_equal(1.234, wts.usd_rate)
   end
+
+  def test_sells
+    WebMock.disable_net_connect!
+    stub_request(:post, 'https://wts.zold.io/do-zld-to-btc')
+      .with(body: hash_including(keygap: 'kg', btc: 'bc1qaddr', amount: '0.5'))
+      .to_return(headers: { 'X-Zold-Job' => 'job-sell' })
+    wts = Zold::WTS.new(KEY, log: Loog::VERBOSE)
+    job = wts.sell('kg', 'bc1qaddr', '0.5')
+
+    assert_equal('job-sell', job)
+  end
+
+  def test_fake_sells
+    assert_equal('job-id', Zold::WTS::Fake.new.sell('kg', 'bc1qaddr', '0.5'))
+  end
 end


### PR DESCRIPTION
Issue #3 asks for a `sell()` method on the WTS gateway so callers of the SDK can convert their ZLD balance to BTC without driving the website. The repository already exposes the symmetric `pay()` method against `https://wts.zold.io/do-pay` and the WTS server defines the corresponding sell endpoint at `POST /do-zld-to-btc` taking `keygap`, `btc`, and `amount` and returning the job id through the `X-Zold-Job` header (see `front/front_btc.rb` in `zold-io/wts.zold.io`).

This change adds `Zold::WTS#sell(keygap, btc, amount)` mirroring `pay()` end to end: it posts the three parameters to `/do-zld-to-btc`, runs the response through the same `clean` and `job_of` helpers, and returns the job id so the caller can pass it to `wait()`. A matching no-op `Zold::WTS::Fake#sell(_keygap, _btc, _amount)` keeps the fake gateway usable in downstream tests. Two new minitest cases stub the endpoint with `webmock` and exercise both the real and the fake implementations offline.

Locally on Ruby 3.3 with the gem `Gemfile.lock`: `bundle exec rake test` runs 10 tests with 0 failures, 0 errors, and 90.72% line coverage. `bundle exec rubocop lib/zold/wts.rb test/zold/test_wts.rb` reports the same pre-existing offences master carries minus one I autocorrected in the new hunk. The CI checks `markdown-lint`, `typos`, `yamllint`, and the `rubocop` step of `test` are red on master at `7c79029` for reasons unrelated to this diff (README badges, `criterias` typo in `lib/zold/wts.rb:140`, yamllint config, `rubocop-rspec_rails inject_defaults!`), so this branch does not introduce new red checks.

Closes #3