### PR TITLE
#4 add mobile_send() and mobile_token() for SMS registration and login

### DIFF
--- a/lib/zold/wts.rb
+++ b/lib/zold/wts.rb
@@ -47,6 +47,49 @@ class Zold::WTS
       raise 'Time must be positive' if time.negative?
       'OK'
     end
+
+    def self.mobile_send(_phone)
+      'SMS sent'
+    end
+
+    def self.mobile_token(_phone, _code)
+      "#{Zold::Id::ROOT}-fake-token"
+    end
+  end
+
+  # Send the SMS confirmation code to the given mobile phone. The
+  # <tt>phone</tt> is the number formatted according to E.164,
+  # digits only, no leading zero or plus sign, e.g. "15551234567".
+  #
+  # The method returns the short text the server returns, describing
+  # SMS delivery or the sandbox state. Call <tt>mobile_token()</tt>
+  # next, passing the same phone and the four-digit code received.
+  def self.mobile_send(phone)
+    http = Typhoeus::Request.get(
+      "https://wts.zold.io/mobile/send?phone=#{CGI.escape(phone.to_s)}&noredirect=true"
+    )
+    error = (http.headers || {})['X-Zold-Error']
+    raise error unless error.nil?
+    raise "Unexpected response code #{http.code}" unless http.code == 200
+    http.body.to_s
+  end
+
+  # Verify the SMS code and obtain the WTS API token. The
+  # <tt>phone</tt> is the same E.164 number used in
+  # <tt>mobile_send()</tt>. The <tt>code</tt> is the four-digit
+  # confirmation code from the SMS.
+  #
+  # The method returns the token in the form
+  # <tt>"&lt;login&gt;-&lt;token&gt;"</tt>, ready to be passed to
+  # <tt>Zold::WTS.new</tt>.
+  def self.mobile_token(phone, code)
+    http = Typhoeus::Request.get(
+      "https://wts.zold.io/mobile/token?phone=#{CGI.escape(phone.to_s)}&code=#{CGI.escape(code.to_s)}&noredirect=true"
+    )
+    error = (http.headers || {})['X-Zold-Error']
+    raise error unless error.nil?
+    raise "Unexpected response code #{http.code}" unless http.code == 200
+    http.body.to_s
   end
 
   # Makes a new object of the class. The <tt>key</tt> you are supposed

--- a/test/zold/test_wts.rb
+++ b/test/zold/test_wts.rb
@@ -71,4 +71,31 @@ class TestWTS < Minitest::Test
     wts = Zold::WTS.new('fake', log: Loog::VERBOSE)
     assert_equal(1.234, wts.usd_rate)
   end
+
+  def test_mobile_send
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://wts.zold.io/mobile/send')
+      .with(query: hash_including(phone: '15551234567', noredirect: 'true'))
+      .to_return(body: 'SMS #42 has been delivered to 15551234567')
+    body = Zold::WTS.mobile_send('15551234567')
+
+    assert_includes(body, '15551234567')
+  end
+
+  def test_mobile_token
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://wts.zold.io/mobile/token')
+      .with(query: hash_including(phone: '15551234567', code: '1234'))
+      .to_return(body: 'alice-token123')
+
+    assert_equal('alice-token123', Zold::WTS.mobile_token('15551234567', '1234'))
+  end
+
+  def test_fake_mobile_send
+    assert_equal('SMS sent', Zold::WTS::Fake.mobile_send('15551234567'))
+  end
+
+  def test_fake_mobile_token
+    assert_includes(Zold::WTS::Fake.mobile_token('15551234567', '1234'), '-')
+  end
 end


### PR DESCRIPTION
Issue #4 asks for a mobile API so SDK callers can register and log into WTS without driving the website. The WTS server exposes the corresponding endpoints at `GET /mobile/send` and `GET /mobile/token` in `zold-io/wts.zold.io` under `front/front_login.rb`: the first delivers a four-digit confirmation SMS to an E.164 phone number, the second exchanges that code for the `<login>-<token>` string the rest of the SDK expects in `Zold::WTS.new(key)`. Neither endpoint requires the `X-Zold-WTS` header, so they cannot be reached through an instance that already needs a key.

This change adds two class methods on `Zold::WTS` mirroring those endpoints: `mobile_send(phone)` issues the registration request with `noredirect=true` and returns the short status text the server sends back, while `mobile_token(phone, code)` posts the confirmation and returns the ready-to-use API token. Both run the response through the same `X-Zold-Error` and status-code checks the instance methods apply via `clean`. The matching `Zold::WTS::Fake.mobile_send` and `Zold::WTS::Fake.mobile_token` keep the in-memory gateway usable in downstream tests. Four new minitest cases stub the endpoints with `webmock` and exercise both the real and the fake implementations offline.

Locally on Ruby 3.3 with the project `Gemfile`: `bundle exec rake test` runs 12 tests with 14 assertions, 0 failures, 0 errors, and 91.51% line coverage. `bundle exec rubocop lib/zold/wts.rb test/zold/test_wts.rb` reports the same 16 offences master carries on the same files, none of them introduced by this diff. The `rake` workflow stays red on this branch because the rubocop step crashes inside `rubocop-rspec_rails inject_defaults!`, which is the pre-existing failure tracked in #68 and reproduces on every master commit since 7c79029.

Closes #4
