### PR TITLE
#63: fix typo in WTS criteria comment

### DIFF
--- a/lib/zold/wts.rb
+++ b/lib/zold/wts.rb
@@ -137,7 +137,7 @@ class Zold::WTS
     clean(Typhoeus::Request.get('https://wts.zold.io/usd_rate')).body.to_f
   end
 
-  # Find transactions by the criteria. All criterias are regular expressions
+  # Find transactions by the criteria. All criteria are regular expressions
   # and their summary result is concatenated by OR. For example, this request
   # will return all transactions that have "pizza" in details OR which
   # are coming from the root wallet:


### PR DESCRIPTION
Fixes #63.

## Summary

This replaces the misspelled word `criterias` with `criteria` in the YARD comment above `Zold::WTS#find`.

The typo is picked up by the `crate-ci/typos` workflow, which makes that CI check noisy on master and on unrelated pull requests.

## Verification

Local:

- `typos`
- `ruby -c lib/zold/wts.rb`
- `git diff --check`

GitHub Actions on this PR:

- `typos` passes
- `actionlint`, `copyrights`, `pdd`, `reuse`, `xcop`, and `yamllint` pass
- `rake` runs the unit tests successfully (`8 runs, 8 assertions, 0 failures`) and then fails in the existing RuboCop/RSpec Rails `inject_defaults!` issue
- `markdown-lint` fails on existing `README.md` formatting issues unrelated to this diff

I also tried `bundle exec rake test` locally, but this macOS environment only has system Ruby 2.6.10. The current dependency resolution selects RuboCop 1.88.0, which requires Ruby >= 2.7, while the project GitHub Actions workflow runs on Ruby 3.3.
