### PR TITLE
Fix typo: "criterias" -> "criteria" in wts.rb

### DIFF
--- a/lib/zold/wts.rb
+++ b/lib/zold/wts.rb
@@ -137,7 +137,7 @@ class Zold::WTS
     clean(Typhoeus::Request.get('https://wts.zold.io/usd_rate')).body.to_f
   end
 
-  # Find transactions by the criteria. All criterias are regular expressions
+  # Find transactions by the criteria. All criteria are regular expressions
   # and their summary result is concatenated by OR. For example, this request
   # will return all transactions that have "pizza" in details OR which
   # are coming from the root wallet:


### PR DESCRIPTION
## Summary
Fixes the typo reported in #63: \`criterias\` → \`criteria\` in the comment at \`lib/zold/wts.rb:140\`.

## Details
- Single occurrence replaced; "criteria" is the correct plural form.
- Resolves the failing typos CI step.

Closes #63